### PR TITLE
feat: implement image generation

### DIFF
--- a/src/handlers/chat.ts
+++ b/src/handlers/chat.ts
@@ -46,11 +46,15 @@ export class ChatHandler {
           }
 
           // Then send the image using InputFile
+          const imageBuffer = parsedResponse.imageUrl instanceof Buffer 
+            ? parsedResponse.imageUrl 
+            : await this.aiService.generateImage(parsedResponse.prompt);
+
           await ctx.replyWithPhoto(
-            new InputFile(Buffer.from(parsedResponse.imageUrl.data), 'generated-image.png'),
+            new InputFile(imageBuffer, 'generated-image.png'),
             {
               caption: BOT_CONFIG.language === 'pl'
-                ? `�� Wygenerowany obraz dla:\n"${parsedResponse.prompt}"`
+                ? `🎨 Wygenerowany obraz dla:\n"${parsedResponse.prompt}"`
                 : `🎨 Generated image for:\n"${parsedResponse.prompt}"`
             }
           );

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ async function startBot() {
   bot.on("message:document", (ctx) => chatHandler.handleDocumentMessage(ctx));
   bot.on("message:voice", (ctx) => chatHandler.handleVoiceMessage(ctx));
 
+  // Add image generation commands
+  bot.command("generate", (ctx) => chatHandler.handleImageGeneration(ctx));
+  bot.command("img", (ctx) => chatHandler.handleImageGeneration(ctx));
+
   bot.catch((err) => {
     const ctx = err.ctx;
     console.error(`Error while handling update ${ctx.update.update_id}:`);


### PR DESCRIPTION
# Add DALL-E Image Generation Feature

## Changes
- Implemented image generation using DALL-E 3 model
- Added direct commands `/generate` and `/img` for image creation
- Integrated automatic image generation in chat conversations using function calling
- Implemented secure image handling with retries and buffering
- Added bilingual support (PL/EN) for image generation responses

## Technical Details
- Updated OpenAI service to use tool calling
- Implemented secure image downloading with retry logic and timeout
- Added buffer-based image handling to prevent URL expiration issues
- Integrated with Grammy's InputFile for reliable image delivery

## Usage
Users can generate images in two ways:
1. Direct commands: `/generate` or `/img` followed by description
2. Natural conversation: AI assistant detects when image generation would be helpful

## Testing
- Tested with various image prompts
- Verified error handling and retry logic
- Confirmed bilingual support